### PR TITLE
Announcement

### DIFF
--- a/ssg/package-lock.json
+++ b/ssg/package-lock.json
@@ -2107,6 +2107,33 @@
       "resolved": "https://registry.npmjs.org/@rexxars/eventsource-polyfill/-/eventsource-polyfill-1.0.0.tgz",
       "integrity": "sha512-YnrybIoM9WFqmeK1D8p/gutqjJnmXCVFWAU3ucka9M7Dzpen3f2Dy4KsC6k1wDHrCtHQuUHHwZovh3i5UPDaZw=="
     },
+    "@sanity/block-content-to-hyperscript": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/block-content-to-hyperscript/-/block-content-to-hyperscript-3.0.0.tgz",
+      "integrity": "sha512-uoXWLdFY5LqO8A9sFJqnZWWDCBC+0r3Egeh0bwKQ2EK2Vil5L40iJGNXMZhDB8BnvH+6B4155SU8Q3vY59T6pA==",
+      "requires": {
+        "@sanity/generate-help-url": "^0.140.0",
+        "@sanity/image-url": "^0.140.15",
+        "hyperscript": "^2.0.2",
+        "object-assign": "^4.1.1"
+      },
+      "dependencies": {
+        "@sanity/generate-help-url": {
+          "version": "0.140.0",
+          "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-0.140.0.tgz",
+          "integrity": "sha512-H/G/WA9S22TXcXST52CIiTsHx3S2hH0gvK7LnI5w76vfKS0obnDPh8jrPg4xeNRYGPuV9MHYRlyERGpRGoo4Qw=="
+        }
+      }
+    },
+    "@sanity/block-content-to-react": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/block-content-to-react/-/block-content-to-react-3.0.0.tgz",
+      "integrity": "sha512-oHPLlIsulsnL3ITs93RIvUPBI6nAeoSFOUf16vX4T7z4wWywxP39N1DF9mAx2tV6Kjr1fJAx5GF7zfiMXYLaqA==",
+      "requires": {
+        "@sanity/block-content-to-hyperscript": "^3.0.0",
+        "prop-types": "^15.6.2"
+      }
+    },
     "@sanity/client": {
       "version": "2.10.5",
       "resolved": "https://registry.npmjs.org/@sanity/client/-/client-2.10.5.tgz",
@@ -3977,6 +4004,11 @@
         "fill-range": "^7.0.1"
       }
     },
+    "browser-split": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
+      "integrity": "sha1-QUGcrvdpdVkp3VGJZ9PuwKYmJ3E="
+    },
     "browserslist": {
       "version": "4.16.6",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
@@ -4411,6 +4443,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+    },
+    "class-list": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/class-list/-/class-list-0.1.1.tgz",
+      "integrity": "sha1-m5dFGSxBebXaCg12M2WOPHDXlss=",
+      "requires": {
+        "indexof": "0.0.1"
+      }
     },
     "class-utils": {
       "version": "0.3.6",
@@ -9608,6 +9648,14 @@
       "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
       "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg="
     },
+    "html-element": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/html-element/-/html-element-2.3.1.tgz",
+      "integrity": "sha512-xnFt2ZkbFcjc+JoAtg3Hl89VeEZDjododu4VCPkRvFmBTHHA9U1Nt6hLUWfW2O+6Sl/rT1hHK/PivleX3PdBJQ==",
+      "requires": {
+        "class-list": "~0.1.1"
+      }
+    },
     "html-entities": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
@@ -9845,6 +9893,16 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
     },
+    "hyperscript": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hyperscript/-/hyperscript-2.0.2.tgz",
+      "integrity": "sha1-ODnLpFVUvf4nu4HCFC0WhPgTWvU=",
+      "requires": {
+        "browser-split": "0.0.0",
+        "class-list": "~0.1.0",
+        "html-element": "^2.0.0"
+      }
+    },
     "hyphenate-style-name": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
@@ -10059,6 +10117,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "inflight": {
       "version": "1.0.6",

--- a/ssg/package.json
+++ b/ssg/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
+    "@sanity/block-content-to-react": "^3.0.0",
     "babel-plugin-styled-components": "^1.12.0",
     "gatsby": "^3.6.2",
     "gatsby-plugin-gatsby-cloud": "^2.6.1",

--- a/ssg/src/components/AnnouncementBar.js
+++ b/ssg/src/components/AnnouncementBar.js
@@ -6,7 +6,7 @@ import CloseIcon from '@material-ui/icons/Close';
 import { IconButton } from '@material-ui/core';
 
 
-export default function AnnouncementBar({ title, linkText }) {
+export default function AnnouncementBar({ title, linkText, modalBlock }) {
   const [open, setOpen] = useState(true)
 
   return (
@@ -15,7 +15,7 @@ export default function AnnouncementBar({ title, linkText }) {
       {linkText && <TransitionsModal 
         modalButtonText={linkText} 
         modalTitle={title} 
-        modalContentHTML={`some content`} />}
+        modalBlock={modalBlock} />}
 
       <IconButton
         edge="start"

--- a/ssg/src/components/AnnouncementBar.js
+++ b/ssg/src/components/AnnouncementBar.js
@@ -11,7 +11,7 @@ export default function AnnouncementBar({ title, linkText }) {
 
   return (
     <AnnouncementBarStyles style={{display: open ? `flex` : `none`}}>
-      <p>{title}</p>
+      <p style={{ marginBottom: `-6px` }}>{title}</p>
       {linkText && <TransitionsModal 
         modalButtonText={linkText} 
         modalTitle={title} 
@@ -29,7 +29,6 @@ export default function AnnouncementBar({ title, linkText }) {
 }
 
 const AnnouncementBarStyles = styled.div`
-  display: flex;
   align-items: center;
   background: var(--primary-light);
   position: relative;

--- a/ssg/src/components/AnnouncementBar.js
+++ b/ssg/src/components/AnnouncementBar.js
@@ -6,16 +6,16 @@ import CloseIcon from '@material-ui/icons/Close';
 import { IconButton } from '@material-ui/core';
 
 
-export default function AnnouncementBar({ announcement }) {
+export default function AnnouncementBar({ title, linkText }) {
   const [open, setOpen] = useState(true)
 
   return (
-    <AnnouncementBarStyles style={ { display: open ? `flex` : `none`, background: announcement.backgroundColor } }>
-      <p className="mr-2">{announcement.announcementTitle}</p>
-      <TransitionsModal 
-        modalButtonText={announcement.announcementLinkText} 
-        modalTitle={announcement.announcementTitle} 
-        modalContentHTML={announcement.announcementPopup } />
+    <AnnouncementBarStyles style={{display: open ? `flex` : `none`}}>
+      <p>{title}</p>
+      {linkText && <TransitionsModal 
+        modalButtonText={linkText} 
+        modalTitle={title} 
+        modalContentHTML={`some content`} />}
 
       <IconButton
         edge="start"
@@ -29,6 +29,8 @@ export default function AnnouncementBar({ announcement }) {
 }
 
 const AnnouncementBarStyles = styled.div`
+  display: flex;
+  align-items: center;
   background: var(--primary-light);
   position: relative;
   text-align: center;

--- a/ssg/src/components/AnnouncementBars.js
+++ b/ssg/src/components/AnnouncementBars.js
@@ -1,11 +1,49 @@
 import React from 'react'
-// import { useStaticQuery, graphql } from "gatsby"
-// import AnnouncementBar from './AnnouncementBar'
+import { useStaticQuery, graphql } from "gatsby"
+import AnnouncementBar from './AnnouncementBar'
 
-export default function AnnouncementBars() {
+export default function AnnouncementBars({ language }) {
+  const { allSanityAnnouncement } = useStaticQuery(graphql`
+    query {
+      allSanityAnnouncement(filter: {isActive: {eq: true}}) {
+        nodes {
+          id
+          title {
+            ar
+            en
+            es
+            fr
+          }
+          linkText {
+            ar
+            en
+            es
+            fr
+          }
+        }
+      }
+    }
+  `)
+  // console.log(allSanityAnnouncement)
+
   return (
     <>
-      {/* {announcements.map(a => <AnnouncementBar key={a.id} announcement={a.announcementBar} /> )} */}
+      {allSanityAnnouncement.nodes.map(node => {
+        const { id, title, linkText } = node
+        const t = title[language] || title.en
+
+        // handle the scenario if the announcement has a link
+        if (linkText) {
+          return (
+            <AnnouncementBar key={id} title={t} linkText={linkText[language] || linkText.en}/>
+            )
+          } else {
+            return (
+            <AnnouncementBar key={id} title={t} />
+          )
+        }
+
+      })}
     </>
   )
 }

--- a/ssg/src/components/AnnouncementBars.js
+++ b/ssg/src/components/AnnouncementBars.js
@@ -20,22 +20,33 @@ export default function AnnouncementBars({ language }) {
             es
             fr
           }
+          modalText {
+            _rawAr(resolveReferences: {maxDepth: 10})
+            _rawEn(resolveReferences: {maxDepth: 10})
+            _rawEs(resolveReferences: {maxDepth: 10})
+            _rawFr(resolveReferences: {maxDepth: 10})
+          }
         }
       }
     }
   `)
-  // console.log(allSanityAnnouncement)
 
-  return (
+return (
     <>
       {allSanityAnnouncement.nodes.map(node => {
-        const { id, title, linkText } = node
+        const { id, title, linkText, modalText } = node
         const t = title[language] || title.en
 
         // handle the scenario if the announcement has a link
         if (linkText) {
+          const rawLangKey = `_raw` + language.charAt(0).toUpperCase() + language.slice(1)
           return (
-            <AnnouncementBar key={id} title={t} linkText={linkText[language] || linkText.en}/>
+            <AnnouncementBar
+              key={id}
+              title={t}
+              linkText={linkText[language] || linkText[`en`]}
+              modalBlock={modalText[rawLangKey] || modalText[`_rawEn`]}
+            />
             )
           } else {
             return (

--- a/ssg/src/components/LanguageSwitcher.js
+++ b/ssg/src/components/LanguageSwitcher.js
@@ -27,7 +27,6 @@ export default function LanguageSwitcher({ language }) {
       className={classes.formControl}
     >
       <Select
-        disableUnderline
         value={language}
         onChange={handleChange}
         IconComponent={LanguageIcon}

--- a/ssg/src/components/Layout.js
+++ b/ssg/src/components/Layout.js
@@ -12,7 +12,7 @@ const Layout = ({ language, noHeader, children }) => (
   <>
     <GlobalStyles />
     <Typography />
-    <AnnouncementBars />
+    <AnnouncementBars language={language} />
 
     {/* Do not display Header on landing page */}
     {!noHeader && <Header language={language} />}

--- a/ssg/src/components/SideDrawer.js
+++ b/ssg/src/components/SideDrawer.js
@@ -4,6 +4,7 @@ import { IconButton, Drawer, List, ListItem, ListItemText } from "@material-ui/c
 import { Menu } from "@material-ui/icons"
 import { makeStyles } from "@material-ui/core/styles"
 import LanguageSwitcher from './LanguageSwitcher'
+import { Link } from 'gatsby'
 
 const useStyles = makeStyles({
   list: {
@@ -44,11 +45,11 @@ export default function SideDrawer({ navLinks, language }) {
     >
       <List component="nav">
         {navLinks.map(({ title, path }) => (
-          <a href={path} key={title} className={classes.linkText}>
+          <Link href={path} key={title} className={classes.linkText}>
             <ListItem button>
               <ListItemText primary={title} />
             </ListItem>
-          </a>
+          </Link>
         ))}
       </List>
     </div>

--- a/ssg/src/components/TransitionsModal.js
+++ b/ssg/src/components/TransitionsModal.js
@@ -4,20 +4,15 @@ import Modal from '@material-ui/core/Modal';
 import Backdrop from '@material-ui/core/Backdrop';
 import Fade from '@material-ui/core/Fade';
 import { Button } from '@material-ui/core';
-
+import BlockContent from '@sanity/block-content-to-react'
 
 const useStyles = makeStyles(() => ({
   btnModal: {
     color: `var(--primary-alt)`,
     textDecoration: `underline`,
-    // background: `transparent`,
-    // border: `none`,
     margin: `0 1rem`,
     textTransform: `unset`,
     padding: `0`,
-    // fontSize: `inherit`,
-    // fontFamily: `inherit`,
-    // padding: `0`,
   },
   modal: {
     display: 'flex',
@@ -26,12 +21,13 @@ const useStyles = makeStyles(() => ({
   },
   paper: {
     backgroundColor: `var(--off-white)`,
-    border: '2px solid #000',
+    border: '2px solid var(--darker)',
     padding: `20px`,
     margin: `20px`,
-    '& h2': {
+    borderRadius: `4px`,
+    '& h3': {
       fontSize: `1.75rem`,
-      marginBottom: `12px`,
+      marginBottom: `1rem`,
     },
     '& p': {
       marginBottom: `6px`,
@@ -42,7 +38,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export default function TransitionsModal({ modalButtonText, modalTitle, modalContentHTML }) {
+export default function TransitionsModal({ modalButtonText, modalTitle, modalBlock }) {
   const classes = useStyles();
   const [open, setOpen] = React.useState(false);
 
@@ -53,6 +49,16 @@ export default function TransitionsModal({ modalButtonText, modalTitle, modalCon
   const handleClose = () => {
     setOpen(false);
   };
+
+  const serializers = {
+    types: {
+      code: (props) => (
+        <pre data-language={props.node.language}>
+          <code>{props.node.code}</code>
+        </pre>
+      ),
+    },
+  }
 
   return (
     <>
@@ -75,6 +81,7 @@ export default function TransitionsModal({ modalButtonText, modalTitle, modalCon
           <div className={classes.paper}>
             <h3 id="transition-modal-title">{modalTitle}</h3>
             <div id="transition-modal-description">
+              <BlockContent blocks={modalBlock} />
             </div>
           </div>
         </Fade>

--- a/ssg/src/components/TransitionsModal.js
+++ b/ssg/src/components/TransitionsModal.js
@@ -13,6 +13,8 @@ const useStyles = makeStyles(() => ({
     // background: `transparent`,
     // border: `none`,
     margin: `0 1rem`,
+    textTransform: `unset`,
+    padding: `0`,
     // fontSize: `inherit`,
     // fontFamily: `inherit`,
     // padding: `0`,

--- a/ssg/src/components/TransitionsModal.js
+++ b/ssg/src/components/TransitionsModal.js
@@ -3,12 +3,19 @@ import { makeStyles } from '@material-ui/core/styles';
 import Modal from '@material-ui/core/Modal';
 import Backdrop from '@material-ui/core/Backdrop';
 import Fade from '@material-ui/core/Fade';
-import ReactHtmlParser from 'react-html-parser';
+import { Button } from '@material-ui/core';
+
 
 const useStyles = makeStyles(() => ({
   btnModal: {
     color: `var(--primary-alt)`,
     textDecoration: `underline`,
+    // background: `transparent`,
+    // border: `none`,
+    margin: `0 1rem`,
+    // fontSize: `inherit`,
+    // fontFamily: `inherit`,
+    // padding: `0`,
   },
   modal: {
     display: 'flex',
@@ -46,10 +53,10 @@ export default function TransitionsModal({ modalButtonText, modalTitle, modalCon
   };
 
   return (
-    <div>
-      <button type="button" onClick={handleOpen} className={classes.btnModal}>
+    <>
+      <Button variant="text" onClick={handleOpen} className={classes.btnModal}>
         {modalButtonText}
-      </button>
+      </Button>
       <Modal
         aria-labelledby="transition-modal-title"
         aria-describedby="transition-modal-description"
@@ -64,13 +71,12 @@ export default function TransitionsModal({ modalButtonText, modalTitle, modalCon
       >
         <Fade in={open}>
           <div className={classes.paper}>
-            <h2 id="transition-modal-title">{modalTitle}</h2>
+            <h3 id="transition-modal-title">{modalTitle}</h3>
             <div id="transition-modal-description">
-              { ReactHtmlParser(modalContentHTML) }
             </div>
           </div>
         </Fade>
       </Modal>
-    </div>
+    </>
   );
 }

--- a/studio/schemas/components/portableText.js
+++ b/studio/schemas/components/portableText.js
@@ -1,5 +1,3 @@
-import pageLink from "../objects/pageLink";
-
 export default {
   name: 'portableText',
   type: 'array',
@@ -7,14 +5,25 @@ export default {
   of: [
     {
       type: 'block',
+      styles: [
+        {title: 'Normal', value: 'normal'},
+        // {title: 'H1', value: 'h1'},
+        // {title: 'H2', value: 'h2'},
+        // {title: 'H3', value: 'h3'},
+        {title: 'H4', value: 'h4'},
+        {title: 'H5', value: 'h5'},
+        {title: 'H6', value: 'h6'},
+        {title: 'Quote', value: 'blockquote'}
+      ],
       marks: {
         decorators: [
-          { "title": "Strong", "value": "strong" },
-          { "title": "Emphasis", "value": "em" },
-          { "title": "Underline", "value": "underline" },
+          { title: 'Strong', value: 'strong' },
+          { title: 'Emphasis', value: 'em' },
+          { title: 'Underline', value: 'underline' },
+          { title: 'Highlight', value: 'highlight' },
         ],
         annotations: [
-          {name: 'pageLink', title: 'Page Link', type: 'pageLink'},
+          { name: 'pageLink', title: 'Page Link', type: 'pageLink' },
           {
             name: 'link',
             type: 'object',
@@ -29,6 +38,7 @@ export default {
 
         ]
       }
-    }
+    },
+    { type: 'imageBlock' }
   ]
 }

--- a/studio/schemas/documents/announcement.js
+++ b/studio/schemas/documents/announcement.js
@@ -1,0 +1,47 @@
+import { GrAnnounce as icon } from 'react-icons/gr'
+
+export default {
+  name: 'announcement',
+  title: 'Announcement',
+  type: 'document',
+  icon,
+  initialValue: {
+    isActive: false,
+  },
+  fields: [
+    {
+      name: 'isActive',
+      title: 'Is Active?',
+      type: 'boolean',
+    },
+    {
+      name: 'title',
+      title: 'Title',
+      description: 'What text do you want to appear on the bar?',
+      type: 'localeString',
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: 'linkText',
+      title: 'Link text to Popup',
+      type: 'localeString',
+      description: 'If you want a popup with more information about your announcement, what text would you like the user to click on to trigger the popup?',
+    },
+    {
+      name: 'modalText',
+      title: 'Popup Text',
+      type: 'localePortableText',
+      description: 'If you want a popup message, what text do you want to appear in the popup? Feel free to include links or anything you like.',
+    },
+  ],
+  preview: {
+    select: {
+      title: 'title',
+    },
+    prepare: ({ title }) => {
+      return {
+        title: title.en,
+      }
+    }
+  }
+}

--- a/studio/schemas/documents/announcement.js
+++ b/studio/schemas/documents/announcement.js
@@ -25,13 +25,23 @@ export default {
       name: 'linkText',
       title: 'Link text to Popup',
       type: 'localeString',
-      description: 'If you want a popup with more information about your announcement, what text would you like the user to click on to trigger the popup?',
+      description: 'Optional. If you want a popup with more information about your announcement, what text would you like the user to click on to trigger the popup?',
     },
     {
       name: 'modalText',
-      title: 'Popup Text',
+      title: 'Popup Message',
       type: 'localePortableText',
-      description: 'If you want a popup message, what text do you want to appear in the popup? Feel free to include links or anything you like.',
+      description: 'Required, when Link text to Popup is defined. This, along with the Title, will be displayed in the popup!',
+      validation: Rule => Rule.custom((field, context) => {
+        // implement popup if linkText is defined, validate that pop up message is defined
+        const isPopup = context.document.linkText[`en`] !== undefined
+
+        if (isPopup && field[`en`] === undefined) {
+          return "Link text to popup isn't empty, hence Popup message must not be empty."
+        } else {
+          return true
+        }
+      })
     },
   ],
   preview: {

--- a/studio/schemas/objects/localizedFields.js
+++ b/studio/schemas/objects/localizedFields.js
@@ -49,4 +49,23 @@ const localeText = {
   }))
 }
 
-export { localeString, localeText }
+const localePortableText = {
+  title: 'Localized portable text',
+  name: 'localePortableText',
+  type: 'object',
+  fieldsets: [
+    {
+      title: 'Translations',
+      name: 'translations',
+      options: { collapsible: true }
+    }
+  ],
+  fields: supportedLanguages.map(lang => ({
+    title: lang.title,
+    name: lang.id,
+    type: 'portableText',
+    fieldset: lang.isDefault ? null : 'translations'
+  }))
+}
+
+export { localeString, localeText, localePortableText }

--- a/studio/schemas/schema.js
+++ b/studio/schemas/schema.js
@@ -29,7 +29,7 @@ import internalLink from './components/internalLink'
 import { homeSections, aboutSections, getSupportSections, contactSections, getInvolvedSections, donateSections } from './objects/sections'
 import { hero, heroAlt } from './objects/hero'
 import pageLink from './objects/pageLink'
-import { localeString, localeText } from './objects/localizedFields'
+import { localePortableText, localeString, localeText } from './objects/localizedFields'
 import portableText from './components/portableText'
 
 // Then we give our schema to the builder and provide the result to Sanity
@@ -68,6 +68,7 @@ export default createSchema({
     // localizedFields
     localeString,
     localeText,
+    localePortableText,
 
     // Components
     imageBlock,

--- a/studio/schemas/schema.js
+++ b/studio/schemas/schema.js
@@ -18,6 +18,7 @@ import navigation from './documents/navigation'
 import siteSettings from './documents/siteSettings'
 
 import partner from './documents/partner'
+import announcement from './documents/announcement'
 
 // import reusable components to schema
 import locale from './components/locale'
@@ -62,6 +63,7 @@ export default createSchema({
     
     // Objects
     partner,
+    announcement,
 
     // localizedFields
     localeString,


### PR DESCRIPTION
- Implemented Announcement with Custom field Validation in Sanity 
- Wired it to Announcement Bar component in Gatsby
- implement portable text for modalText using npm package [block-content-to-react](https://github.com/sanity-io/block-content-to-react)
- Accounted for Localization

TODO: account for styling for > 1 announcement | text block content rendering